### PR TITLE
revert bre-http-client string token changes

### DIFF
--- a/projects/bloomreach-experience-ng-sdk/src/lib/services/page-model.service.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/services/page-model.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Injector } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 
 import { BehaviorSubject, Observable, of, Subject} from 'rxjs';
@@ -22,7 +22,6 @@ export class PageModelService {
   channelManagerApi: any;
   pageModel: any;
   pageModelSubject: Subject<any> = new BehaviorSubject<any>(this.pageModel);
-  http: HttpClient;
 
   private httpGetOptions = {
     withCredentials: true
@@ -34,29 +33,10 @@ export class PageModelService {
   };
 
   constructor(
-    private injector: Injector,
     private apiUrlsService: ApiUrlsService,
-    private requestContextService: RequestContextService
-  ) {
-    this.resolveHttpClient();
-  }
-
-  private resolveHttpClient(): void {
-    try {
-      this.http = this.injector.get('bre-http-client');
-    } catch {}
-
-    if (!this.http) {
-      try {
-        this.http = this.injector.get(HttpClient);
-      } catch {
-        throw new Error(`Couldn't resolve HttpClient.
-          Please make sure to import HttpClientModule in your app root module and
-          provide HttpClient class for the 'bre-http-client' token`);
-      }
-    }
-  }
-
+    private requestContextService: RequestContextService,
+    private http: HttpClient
+  ) {}
   fetchPageModel(): any {
     const apiUrl: string = this.buildApiUrl();
     return this.http.get<any>(apiUrl, this.httpGetOptions).pipe(


### PR DESCRIPTION
Originally this string token was added to get around static injection errors related to different instances of `HttpClient` being injected into the bloomreach services in this last [this PR](https://github.com/bloomreach/experience-ng-sdk/pull/10) for more details.

Now in our project we're adding the `@angular/common/http` dependency as an external when building the lobs, allowing for the correct instance of `HttpClient` to be loaded. Removing the string token as it's not needed anymore.

