### PR TITLE
Resolve CMS-12105 & CMS-12106

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ components. There's also an API section below that includes more details.
 
 ```typescript
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { ApiUrlsService, ComponentMappingsService, InitializeSdkService, RequestContextService } from 'bloomreach-experience-ng-sdk';
 
 @Component({
@@ -68,15 +69,18 @@ export class MyAppClass implements OnInit {
     }
   }
   
-  constructor(private apiUrlsService: ApiUrlsService,
-              private componentMappingsService: ComponentMappingsService,
-              private initializeSdkService: InitializeSdkService,
-              private requestContextService: RequestContextService) {}
+  constructor(
+    private router: Router,
+    private apiUrlsService: ApiUrlsService,
+    private componentMappingsService: ComponentMappingsService,
+    private initializeSdkService: InitializeSdkService,
+    private requestContextService: RequestContextService
+  ) {}
 
   ngOnInit() {
     this.apiUrlsService.setApiUrls(this.apiUrls);
     this.componentMappingsService.setComponentMappings(this.componentMappings);
-    this.requestContextService.parseUrlPath(window.location.pathname);
+    this.requestContextService.parseUrlPath(this.router.url);
     this.initializeSdkService.initialize();
   }
 }
@@ -372,8 +376,9 @@ Service that handles initialization of the SDK, including:
 
 #### Methods
 
-- `initialize()` - `None` initializes the SDK by fetching the Page Model and initializing 
- the Channel manager integration.
+- `initialize({initializePageModel = true, initializeRouterEvents = true}): Subscription | void` - initializes the SDK by fetching the Page Model and initializing the Channel manager integration. Returns router events subscription or void if `initializeRouterEvents` is `false`.
+  - `initializePageModel: boolean` - flag to fetch the Page Model on initialization;
+  - `initializeRouterEvents: boolean` - flag to subscribe for router events.
 
 ### `PageModelService`
 

--- a/README.md
+++ b/README.md
@@ -398,22 +398,34 @@ consequently Channel Manager functionality is enabled.
 
 #### Methods
 
-- `parseUrlPath(urlPath: string)` - `None` parses the current URL-path for detecting the 
+- `parseUrlPath(urlPath: string): void` - parses the current URL-path for detecting the
  current URL and preview detection.
-- `parseRequest(request: Request)` - `None` parses the current request for detecting the 
- current URL and preview detection. See `Request` type below for format of the `request` 
+- `parseRequest(request: Request): void` - parses the current request for detecting the
+ current URL and preview detection. See `Request` type below for format of the `request`
  parameter.
-- `isPreviewRequest()` - `Boolean` returns if preview mode is active/detected.
-- `getDebugging()` - `Boolean` returns if debugging mode is enabled or not
-- `setDebugging(debugging: boolean)` - `None` sets debugging mode which enables detailed 
+- `isPreviewRequest(): boolean` - returns if preview mode is active/detected.
+- `getDebugging(): boolean` - returns if debugging mode is enabled or not
+- `setDebugging(debugging: boolean): void` - sets debugging mode which enables detailed
  logging on request parsing, Channel Manager integration, and component updates.
 
 #### `Request` type
 
-- `hostname`: `String` should contain the hostname for the current request (client-side 
- this is window.location.hostname)
-- `path`: `String` should contain the URL-path for the current request (client-side this 
- is window.location.pathname)
+- `hostname: string` - should contain the hostname for the current request:
+  - `window.location.hostname` for client-side rendering (Browser Platform);
+  - `self.location.hostname` for Web Workers (Worker Platform);
+  - `request.hostname` for server-side rendering (Server Platform/Angular Universal).
+    For server-side rendering, the SDK expects the request to be injected as `REQUEST` token:
+    ```javascript
+    import { REQUEST } from 'bloomreach-experience-ng-sdk';
+
+    // ...
+    providers: [
+      { provide: REQUEST, useValue: request },
+    ],
+    // ...
+    ```
+
+- `path: string` - should contain the URL-path for the current request (client-side this is window.location.pathname).
 
 ### `<bre-render-cms-component>`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bloomreach-experience-ng-sdk-csr-app",
-  "version": "0.1.1-rc1",
+  "version": "0.2.0",
   "scripts": {
     "ng": "ng",
     "start": "ng build --prod bloomreach-experience-ng-sdk && ng serve",

--- a/projects/bloomreach-experience-ng-sdk/package.json
+++ b/projects/bloomreach-experience-ng-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bloomreach-experience-ng-sdk",
-  "version": "0.1.1-rc1",
+  "version": "0.2.0",
   "peerDependencies": {
     "@angular/common": "^6.0.0-rc.0 || ^6.0.0",
     "@angular/core": "^6.0.0-rc.0 || ^6.0.0",

--- a/projects/bloomreach-experience-ng-sdk/src/lib/common-sdk/types.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/common-sdk/types.ts
@@ -28,7 +28,7 @@ export interface Request {
 }
 
 export class RequestContext {
-  constructor(public path: string, public preview: boolean) {}
+  constructor(public path: string, public preview: boolean, public query: string) {}
 }
 
 export interface ComponentMappings {

--- a/projects/bloomreach-experience-ng-sdk/src/lib/common-sdk/utils/initialize-cms-integration.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/common-sdk/utils/initialize-cms-integration.ts
@@ -1,12 +1,12 @@
-export function _initializeCmsIntegration(onCmsInitialization: Function, renderComponent: Function): void {
+export type InitFunction = (cms) => void;
+export type RenderFunction = (id, propertiesMap) => void;
+
+declare const window: {
+  SPA?: { init: InitFunction, renderComponent: RenderFunction },
+};
+
+export function _initializeCmsIntegration(init: InitFunction, renderComponent: RenderFunction) {
   if (typeof window !== 'undefined') {
-    (<any>window).SPA = {
-      init: (cms) => {
-        onCmsInitialization(cms);
-      },
-      renderComponent: (id, propertiesMap) => {
-        renderComponent(id, propertiesMap);
-      }
-    };
+    window.SPA = { init, renderComponent };
   }
 }

--- a/projects/bloomreach-experience-ng-sdk/src/lib/common-sdk/utils/page-model.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/common-sdk/utils/page-model.ts
@@ -1,7 +1,8 @@
 import jsonpointer from 'jsonpointer';
-
 import { ApiUrls, EnvironmentApiUrls } from '../types';
 import { addPageMetaData } from './cms-meta-data';
+
+const SSO_HANDSHAKE = /(?:^|&)(org.hippoecm.hst.container.render_host=.+?)(?:&|$)/;
 
 export function updatePageMetaData(pageModel: any, channelManagerApi: any, preview: boolean, debugging: boolean): void {
   addPageMetaData(pageModel, preview);
@@ -11,7 +12,7 @@ export function updatePageMetaData(pageModel: any, channelManagerApi: any, previ
   }
 }
 
-export function _buildApiUrl(apiUrls: ApiUrls, preview: boolean, urlPath: string, componentId?: string): string {
+export function _buildApiUrl(apiUrls: ApiUrls, preview: boolean, urlPath: string, query: string, componentId?: string): string {
   // use either preview or live URLs
   const envApiUrls: EnvironmentApiUrls = preview ? apiUrls.preview : apiUrls.live;
 
@@ -34,6 +35,12 @@ export function _buildApiUrl(apiUrls: ApiUrls, preview: boolean, urlPath: string
   if (componentId) {
     url = addComponentRenderingURL(url, componentId, apiUrls);
   }
+
+  const [, ssoHandshake = ''] = (query && query.match(SSO_HANDSHAKE)) || [];
+  if (ssoHandshake) {
+    url += (url.indexOf('?') === -1 ? '?' : '&') + ssoHandshake;
+  }
+
   return url;
 }
 

--- a/projects/bloomreach-experience-ng-sdk/src/lib/common-sdk/utils/request-context.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/common-sdk/utils/request-context.ts
@@ -29,33 +29,15 @@ function getPathFromParsedUrl(parsedUrlPath: string, regexpKeys: pathToRegexp.Ke
   return '';
 }
 
-function detectPreview(request: Request, apiUrls: ApiUrls, parsedUrlPath: string, regexpKeys: pathToRegexp.Key[]): boolean {
-  if (!request.hostname) {
-    return false;
-  }
-
-  const hostname: string = getHostname(request.hostname);
-
-  // detect CMS/preview mode using query parameter
-  let preview: boolean = hasPreviewQueryParameter(request.path);
-  if (!preview) {
-    // otherwise use hostname
-    preview = isMatchingPreviewHostname(hostname, apiUrls);
-  }
-  if (!preview) {
-    // or use preview prefix for preview detection
-    preview = hasPreviewPathPrefix(parsedUrlPath, regexpKeys);
-  }
-
-  return preview;
+function detectPreview(request: Request, apiUrls: ApiUrls, parsedUrlPath: string, regexpKeys: pathToRegexp.Key[]) {
+  return hasPreviewQueryParameter(request.path)
+    || hasPreviewPathPrefix(parsedUrlPath, regexpKeys)
+    || request.hostname && isMatchingPreviewHostname(getHostname(request.hostname), apiUrls);
 }
 
 // removes port number from hostname
-function getHostname(hostname: string): string {
-  if (hostname.indexOf(':') !== -1) {
-    return hostname.substring(0, hostname.indexOf(':'));
-  }
-  return hostname;
+function getHostname(hostname: string) {
+  return hostname.split(':', 2)[0];
 }
 
 function hasPreviewQueryParameter(urlPath: string): boolean {

--- a/projects/bloomreach-experience-ng-sdk/src/lib/common-sdk/utils/request-context.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/common-sdk/utils/request-context.ts
@@ -37,7 +37,7 @@ function detectPreview(request: Request, apiUrls: ApiUrls, parsedUrlPath: string
 
 // removes port number from hostname
 function getHostname(hostname: string) {
-  return hostname.split(':', 2)[0];
+  return hostname.split(':', 1)[0];
 }
 
 function hasPreviewQueryParameter(urlPath: string): boolean {

--- a/projects/bloomreach-experience-ng-sdk/src/lib/common-sdk/utils/request-context.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/common-sdk/utils/request-context.ts
@@ -3,10 +3,10 @@ import pathToRegexp from 'path-to-regexp';
 import { ApiUrls, CompiledPathRegexp, Request, RequestContext } from '../types';
 
 export function _parseRequest(request: Request, compiledPathRegexp: CompiledPathRegexp, apiUrls: ApiUrls, debug: boolean): RequestContext {
-  const parsedUrlPath: string = compiledPathRegexp.regexp.exec(request.path);
-
-  const path: string = getPathFromParsedUrl(parsedUrlPath, compiledPathRegexp.regexpKeys);
-  const preview: boolean = detectPreview(request, apiUrls, parsedUrlPath, compiledPathRegexp.regexpKeys);
+  const [urlPath] = request.path.split('?', 2);
+  const parsedUrlPath = compiledPathRegexp.regexp.exec(urlPath);
+  const path = getPathFromParsedUrl(parsedUrlPath, compiledPathRegexp.regexpKeys);
+  const preview = detectPreview(request, apiUrls, parsedUrlPath, compiledPathRegexp.regexpKeys);
 
   if (debug) {
     console.log(`### SDK debugging ### parsing URL-path '%s'`, request.path);

--- a/projects/bloomreach-experience-ng-sdk/src/lib/common-sdk/utils/request-context.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/common-sdk/utils/request-context.ts
@@ -3,7 +3,7 @@ import pathToRegexp from 'path-to-regexp';
 import { ApiUrls, CompiledPathRegexp, Request, RequestContext } from '../types';
 
 export function _parseRequest(request: Request, compiledPathRegexp: CompiledPathRegexp, apiUrls: ApiUrls, debug: boolean): RequestContext {
-  const [urlPath] = request.path.split('?', 2);
+  const [urlPath, query = ''] = request.path.split('?', 2);
   const parsedUrlPath = compiledPathRegexp.regexp.exec(urlPath);
   const path = getPathFromParsedUrl(parsedUrlPath, compiledPathRegexp.regexpKeys);
   const preview = detectPreview(request, apiUrls, parsedUrlPath, compiledPathRegexp.regexpKeys);
@@ -14,7 +14,7 @@ export function _parseRequest(request: Request, compiledPathRegexp: CompiledPath
     console.log(`### SDK debugging ### preview mode is %s`, preview);
   }
 
-  return new RequestContext(path, preview);
+  return new RequestContext(path, preview, query);
 }
 
 function getPathFromParsedUrl(parsedUrlPath: string, regexpKeys: pathToRegexp.Key[]): string {

--- a/projects/bloomreach-experience-ng-sdk/src/lib/services/initialize-sdk.service.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/services/initialize-sdk.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { NavigationEnd, Router } from '@angular/router';
 import { RequestContextService } from './request-context.service';
 import { PageModelService } from './page-model.service';
@@ -11,13 +12,14 @@ export class InitializeSdkService {
   constructor(
     private pageModelService: PageModelService,
     private requestContextService: RequestContextService,
-    private router: Router
+    private router: Router,
+    @Inject(PLATFORM_ID) private platformId,
   ) {
     this.onCmsInitialization = this.onCmsInitialization.bind(this);
     this.onComponentUpdate = this.onComponentUpdate.bind(this);
   }
 
-  initialize({initializePageModel = true, initializeRouterEvents = true} = {}) {
+  initialize({initializePageModel = true, initializeRouterEvents = true} = {}): Subscription | void {
     this.initializeCmsIntegration();
 
     if (initializePageModel) {
@@ -32,7 +34,9 @@ export class InitializeSdkService {
   }
 
   protected initializeCmsIntegration() {
-    _initializeCmsIntegration(this.onCmsInitialization, this.onComponentUpdate);
+    if (isPlatformBrowser(this.platformId)) {
+      _initializeCmsIntegration(this.onCmsInitialization, this.onComponentUpdate);
+    }
   }
 
   protected initializeRouterEvents() {

--- a/projects/bloomreach-experience-ng-sdk/src/lib/services/page-model.service.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/services/page-model.service.ts
@@ -90,10 +90,12 @@ export class PageModelService {
   }
 
   private buildApiUrl(componentId?: string): string {
-    const apiUrls: ApiUrls = this.apiUrlsService.getApiUrls();
-    const preview: boolean = this.requestContextService.isPreviewRequest();
-    const urlPath: string = this.requestContextService.getPath();
-    return _buildApiUrl(apiUrls, preview, urlPath, componentId);
+    const apiUrls = this.apiUrlsService.getApiUrls();
+    const preview = this.requestContextService.isPreviewRequest();
+    const urlPath = this.requestContextService.getPath();
+    const query = this.requestContextService.getQuery();
+
+    return _buildApiUrl(apiUrls, preview, urlPath, query, componentId);
   }
 
   /**

--- a/projects/bloomreach-experience-ng-sdk/src/lib/services/request-context.service.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/services/request-context.service.ts
@@ -33,6 +33,10 @@ export class RequestContextService {
     return this.requestContext.path;
   }
 
+  getQuery() {
+    return this.requestContext.query;
+  }
+
   parseUrlPath(path: string) {
     let hostname = '';
 

--- a/src/app/bre-page-demo/bre-page-demo.component.ts
+++ b/src/app/bre-page-demo/bre-page-demo.component.ts
@@ -29,12 +29,13 @@ export class BrePageDemoComponent implements OnInit {
 
   menuComponent = MenuComponent;
 
-  constructor(private router: Router,
+  constructor(
+    private router: Router,
     private apiUrlsService: ApiUrlsService,
     private componentMappingsService: ComponentMappingsService,
     private initializeSdkService: InitializeSdkService,
-    private requestContextService: RequestContextService) {
-    }
+    private requestContextService: RequestContextService
+  ) {}
 
   ngOnInit() {
     this.apiUrlsService.setApiUrls(this.apiUrls);


### PR DESCRIPTION
This pull-request has the following changes:
- Fix incorrect Page Model API URL when there is a query string in the page URL.
- Add SSO handshake introduced in 13.X.
- Fix error with undefined `window` object in an app running with Angular Universal.
- Add correct platform-specific hostname detection.
- Add the possibility to pass the request object on server-side rendering via `REQUEST` token.