### PR TITLE
Update SDK to support Angular TransferState API

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ Service that handles initialization of the SDK, including:
 - Fetching initial Page Model via `PageModelService`, and updates to the Page Model on 
  navigation changes or component updates in the CMS.
 - Initializating the Channel Manager integration.
+- Restoring the Page Model state using [Transfer State API](https://angular.io/api/platform-browser/TransferState). To use it import [ServerTransferStateModule](https://angular.io/api/platform-server/ServerTransferStateModule) on the server and [BrowserTransferStateModule](https://angular.io/api/platform-browser/BrowserTransferStateModule) on the client.
 
 #### Methods
 
@@ -389,6 +390,7 @@ Fetches the Page Model API and manages state.
 - `getPageModel()` - `Object` return the Page Model. Please note that this is a 
  synchronous call, so if this is called during initialization, the Page Model might not
  have been set yet. Use `getPageModelSubject()` in these cases.
+- `setPageModel(value: any)` - update the Page Model and push the value to the Page Model subject (see `getPageModelSubject()`).
 - `getPageModelSubject()` `Subject<Object>` return a subject of the Page Model that can be 
  subscribed to for asynchronous access to the Page Model.
 - `getContentViaReference(contentRef: string)` - `Object` returns content item from Page 

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Service that handles initialization of the SDK, including:
 - `initialize({initializePageModel = true, initializeRouterEvents = true}): Subscription | void` - initializes the SDK by fetching the Page Model and initializing the Channel manager integration. Returns router events subscription or void if `initializeRouterEvents` is `false`.
   - `initializePageModel: boolean` - flag to fetch the Page Model on initialization;
   - `initializeRouterEvents: boolean` - flag to subscribe for router events.
+  - `transferState: boolean` - flag to use Angular's TransferState API during Server Side Rendering to prevent the page from being reloaded once Angular loads in the browser
 
 ### `PageModelService`
 

--- a/README.md
+++ b/README.md
@@ -379,7 +379,6 @@ Service that handles initialization of the SDK, including:
 - `initialize({initializePageModel = true, initializeRouterEvents = true}): Subscription | void` - initializes the SDK by fetching the Page Model and initializing the Channel manager integration. Returns router events subscription or void if `initializeRouterEvents` is `false`.
   - `initializePageModel: boolean` - flag to fetch the Page Model on initialization;
   - `initializeRouterEvents: boolean` - flag to subscribe for router events.
-  - `transferState: boolean` - flag to use Angular's TransferState API during Server Side Rendering to prevent the page from being reloaded once Angular loads in the browser
 
 ### `PageModelService`
 

--- a/projects/bloomreach-experience-ng-sdk/src/lib/common-sdk/utils/page-model.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/common-sdk/utils/page-model.ts
@@ -109,7 +109,6 @@ export function _updateComponent(
       }
       Object.assign(pageModel.content, response.content);
     }
-    updatePageMetaData(pageModel, channelManagerApi, preview, debugging);
   }
   return pageModel;
 }

--- a/projects/bloomreach-experience-ng-sdk/src/lib/services/initialize-sdk.service.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/services/initialize-sdk.service.ts
@@ -35,8 +35,12 @@ export class InitializeSdkService {
     this.onComponentUpdate = this.onComponentUpdate.bind(this);
   }
 
-  initialize({initializePageModel = true, initializeRouterEvents = true} = {}): Subscription | void {
+  initialize({initializePageModel = true, initializeRouterEvents = true, transferState = false} = {}): Subscription | void {
     this.initializeCmsIntegration();
+
+    if (transferState) {
+      this.requestContextService.setTransferState(transferState);
+    }
 
     if (initializePageModel) {
       this.fetchPageModel();

--- a/projects/bloomreach-experience-ng-sdk/src/lib/services/initialize-sdk.service.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/services/initialize-sdk.service.ts
@@ -14,14 +14,18 @@
  * limitations under the License.
  */
 
-import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
+import { Inject, Injectable, Optional, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser, isPlatformServer } from '@angular/common';
+import { makeStateKey, TransferState } from '@angular/platform-browser';
 import { NavigationEnd, Router } from '@angular/router';
 import { RequestContextService } from './request-context.service';
 import { PageModelService } from './page-model.service';
 import { _initializeCmsIntegration } from '../common-sdk/utils/initialize-cms-integration';
 import { logCmsCreateOverlay } from '../common-sdk/utils/page-model';
 import { Observable, Subscription } from 'rxjs';
+import { first } from 'rxjs/operators';
+
+const PAGE_MODEL_STATE_KEY = 'pageModel';
 
 @Injectable({ providedIn: 'root' })
 export class InitializeSdkService {
@@ -30,20 +34,17 @@ export class InitializeSdkService {
     private requestContextService: RequestContextService,
     private router: Router,
     @Inject(PLATFORM_ID) private platformId,
+    @Optional() @Inject(TransferState) private transferState: TransferState,
   ) {
     this.onCmsInitialization = this.onCmsInitialization.bind(this);
     this.onComponentUpdate = this.onComponentUpdate.bind(this);
   }
 
-  initialize({initializePageModel = true, initializeRouterEvents = true, transferState = false} = {}): Subscription | void {
+  initialize({initializePageModel = true, initializeRouterEvents = true} = {}): Subscription | void {
     this.initializeCmsIntegration();
 
-    if (transferState) {
-      this.requestContextService.setTransferState(transferState);
-    }
-
     if (initializePageModel) {
-      this.fetchPageModel();
+      this.initializePageModel();
     }
 
     if (initializeRouterEvents) {
@@ -59,20 +60,33 @@ export class InitializeSdkService {
     }
   }
 
+  protected initializePageModel() {
+    const stateKey = this.transferState && makeStateKey(PAGE_MODEL_STATE_KEY);
+    const hasState = !isPlatformServer(this.platformId) && this.transferState && this.transferState.hasKey(stateKey);
+    const $pageModel = hasState
+      ? this.pageModelService.setPageModel(this.transferState.get(stateKey, null))
+      : this.pageModelService.fetchPageModel();
+
+    $pageModel
+      .pipe(first())
+      .subscribe(() => {
+        if (hasState) {
+          this.transferState.remove(stateKey);
+        }
+      });
+
+    if (isPlatformServer(this.platformId) && this.transferState) {
+      this.transferState.onSerialize(stateKey, () => this.pageModelService.pageModel);
+    }
+  }
+
   protected initializeRouterEvents() {
     return this.router.events.subscribe(event => {
       if (event instanceof NavigationEnd) {
         this.requestContextService.parseUrlPath(event.url);
-        this.fetchPageModel();
+        this.initializePageModel();
       }
     });
-  }
-
-  protected fetchPageModel() {
-    const pageModel$ = this.pageModelService.fetchPageModel();
-    pageModel$.subscribe();
-
-    return pageModel$;
   }
 
   private onCmsInitialization(cms: any) {

--- a/projects/bloomreach-experience-ng-sdk/src/lib/services/page-model.service.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/services/page-model.service.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {Inject, Injectable, Injector, PLATFORM_ID} from '@angular/core';
+import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { BehaviorSubject, Observable, of, Subject} from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
@@ -28,15 +28,12 @@ import {
   updatePageMetaData,
   toUrlEncodedFormData
 } from '../common-sdk/utils/page-model';
-import {makeStateKey, TransferState} from '@angular/platform-browser';
-import {isPlatformServer} from '@angular/common';
 
 @Injectable({ providedIn: 'root' })
 export class PageModelService {
   channelManagerApi: any;
   pageModel: any;
   pageModelSubject: Subject<any> = new BehaviorSubject<any>(this.pageModel);
-  private transferState: TransferState = null;
 
   private httpGetOptions = {
     withCredentials: true
@@ -51,43 +48,16 @@ export class PageModelService {
     private apiUrlsService: ApiUrlsService,
     private requestContextService: RequestContextService,
     private http: HttpClient,
-    @Inject(PLATFORM_ID) private platformId,
-    private injector: Injector
   ) {
     this.pageModelSubject.subscribe(() => this.processPageModel());
   }
 
   fetchPageModel() {
     const apiUrl: string = this.buildApiUrl();
-    const PAGE_KEY = makeStateKey<any>('pagemodel');
-
-    // check if transferState is enabled
-    if (this.requestContextService.getTransferState()) {
-      this.transferState = <TransferState> this.injector.get(TransferState);
-    }
-
-    // Check if TransferState is enabled and to see if Page model exists on transferState
-    if (this.requestContextService.getTransferState() && this.transferState.hasKey(PAGE_KEY)) {
-      this.pageModel  = this.transferState.get<any>(PAGE_KEY, null);
-      this.transferState.remove(PAGE_KEY);
-      this.processPageModel();
-      return of(this.pageModel );
-    } else {
-
-      return this.http.get<any>(apiUrl, this.httpGetOptions).pipe(
-        tap(response => {
-
-          // if on server save the page model.
-          if ( this.requestContextService.getTransferState() && isPlatformServer(this.platformId)) {
-            this.transferState.set(PAGE_KEY, response);
-          }
-
-          this.pageModel = response;
-          this.processPageModel();
-        }),
-        catchError(this.handleError('fetchPageModel', undefined))
-      );
-    }
+    return this.http.get<any>(apiUrl, this.httpGetOptions).pipe(
+      tap(response => void this.setPageModel(response)),
+      catchError(this.handleError('fetchPageModel', undefined))
+    );
   }
 
   private processPageModel() {

--- a/projects/bloomreach-experience-ng-sdk/src/lib/services/page-model.service.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/services/page-model.service.ts
@@ -53,7 +53,9 @@ export class PageModelService {
     private http: HttpClient,
     @Inject(PLATFORM_ID) private platformId,
     private injector: Injector
-  ) {  }
+  ) {
+    this.pageModelSubject.subscribe(() => this.processPageModel());
+  }
 
   fetchPageModel() {
     const apiUrl: string = this.buildApiUrl();
@@ -88,10 +90,13 @@ export class PageModelService {
     }
   }
 
-  private processPageModel (): void {
-    this.setPageModelSubject(this.pageModel );
-    const preview: boolean = this.requestContextService.isPreviewRequest();
-    const debugging: boolean = this.requestContextService.getDebugging();
+  private processPageModel() {
+    if (!this.pageModel) {
+      return;
+    }
+
+    const preview = this.requestContextService.isPreviewRequest();
+    const debugging = this.requestContextService.getDebugging();
     updatePageMetaData(this.pageModel.page, this.channelManagerApi, preview, debugging);
   }
 
@@ -100,12 +105,15 @@ export class PageModelService {
     return this.pageModel;
   }
 
-  getPageModelSubject(): Subject<any> {
-    return this.pageModelSubject;
+  setPageModel(value: any) {
+    this.pageModel = value;
+    this.pageModelSubject.next(value);
+
+    return this.pageModelSubject.asObservable();
   }
 
-  private setPageModelSubject(pageModel: any): void {
-    this.pageModelSubject.next(pageModel);
+  getPageModelSubject(): Subject<any> {
+    return this.pageModelSubject;
   }
 
   setChannelManagerApi(channelManagerApi: any): void {
@@ -122,9 +130,15 @@ export class PageModelService {
 
     return this.http.post<any>(url, body, this.httpPostOptions).pipe(
       tap(response => {
-        const preview: boolean = this.requestContextService.isPreviewRequest();
-        this.pageModel = _updateComponent(response, componentId, this.pageModel, this.channelManagerApi, preview, debugging);
-        this.setPageModelSubject(this.pageModel);
+        const preview = this.requestContextService.isPreviewRequest();
+        this.setPageModel(_updateComponent(
+          response,
+          componentId,
+          this.pageModel,
+          this.channelManagerApi,
+          preview,
+          debugging
+        ));
       }),
       catchError(this.handleError('updateComponent', undefined)));
   }

--- a/projects/bloomreach-experience-ng-sdk/src/lib/services/request-context.service.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/services/request-context.service.ts
@@ -26,11 +26,12 @@ export const REQUEST = new InjectionToken<string>('request');
 export class RequestContextService {
   private requestContext: RequestContext;
   private debugging = false;
+  private transferState = false;
 
   constructor(
     private apiUrlsService: ApiUrlsService,
     @Inject(PLATFORM_ID) private platformId,
-    @Optional() @Inject(REQUEST) private request,
+    @Optional() @Inject(REQUEST) private request
   ) {}
 
   getDebugging() {
@@ -73,5 +74,13 @@ export class RequestContextService {
     const apiUrls = this.apiUrlsService.getApiUrls();
     const compiledPathRegexp = this.apiUrlsService.getCompiledPathRegexp();
     this.requestContext = _parseRequest(request, compiledPathRegexp, apiUrls, this.debugging);
+  }
+
+  getTransferState(): boolean {
+    return this.transferState;
+  }
+
+  setTransferState(transferState: boolean): void {
+    this.transferState = transferState;
   }
 }

--- a/projects/bloomreach-experience-ng-sdk/src/lib/services/request-context.service.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/services/request-context.service.ts
@@ -26,12 +26,11 @@ export const REQUEST = new InjectionToken<string>('request');
 export class RequestContextService {
   private requestContext: RequestContext;
   private debugging = false;
-  private transferState = false;
 
   constructor(
     private apiUrlsService: ApiUrlsService,
     @Inject(PLATFORM_ID) private platformId,
-    @Optional() @Inject(REQUEST) private request
+    @Optional() @Inject(REQUEST) private request,
   ) {}
 
   getDebugging() {
@@ -74,13 +73,5 @@ export class RequestContextService {
     const apiUrls = this.apiUrlsService.getApiUrls();
     const compiledPathRegexp = this.apiUrlsService.getCompiledPathRegexp();
     this.requestContext = _parseRequest(request, compiledPathRegexp, apiUrls, this.debugging);
-  }
-
-  getTransferState(): boolean {
-    return this.transferState;
-  }
-
-  setTransferState(transferState: boolean): void {
-    this.transferState = transferState;
   }
 }


### PR DESCRIPTION
Changes to the SDK to support the Angular TransferState API. This prevents the page from flickering when Angular is loaded in the browser when using Server Side Rendering. 

To enable this you have to pass true as the third option to the initialize function. 

The fetchPageModel function has been updated to check if TransferState is enabled. When it is enabled it stores and retrieves the page model from the state. 

This is to fix Staples request STAPLES-68