### PR TITLE
make httpClient optional

### DIFF
--- a/projects/bloomreach-experience-ng-sdk/src/lib/bloomreach-experience-ng-sdk.module.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/bloomreach-experience-ng-sdk.module.ts
@@ -45,12 +45,12 @@ import { InitializeSdkService } from './services/initialize-sdk.service';
     CmsEditButtonComponent,
     RenderCmsComponent,
   ],
-  entryComponents: [UndefinedComponent],
+  entryComponents: [ UndefinedComponent ],
   imports: [
     CommonModule,
     RouterModule,
   ],
-  exports: [CmsEditButtonComponent, RenderCmsComponent]
+  exports: [CmsEditButtonComponent, RenderCmsComponent ]
 })
 export class BloomreachExperienceNgSdkModule {
   static forRoot(): ModuleWithProviders {

--- a/projects/bloomreach-experience-ng-sdk/src/lib/bloomreach-experience-ng-sdk.module.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/bloomreach-experience-ng-sdk.module.ts
@@ -16,7 +16,6 @@
 
 import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { HttpClientModule } from '@angular/common/http';
 import { RouterModule } from '@angular/router';
 
 import { ApiUrlsService } from './services/api-urls.service';
@@ -46,13 +45,12 @@ import { InitializeSdkService } from './services/initialize-sdk.service';
     CmsEditButtonComponent,
     RenderCmsComponent,
   ],
-  entryComponents: [ UndefinedComponent ],
+  entryComponents: [UndefinedComponent],
   imports: [
     CommonModule,
-    HttpClientModule,
     RouterModule,
   ],
-  exports: [CmsEditButtonComponent, RenderCmsComponent ]
+  exports: [CmsEditButtonComponent, RenderCmsComponent]
 })
 export class BloomreachExperienceNgSdkModule {
   static forRoot(): ModuleWithProviders {

--- a/projects/bloomreach-experience-ng-sdk/src/lib/services/initialize-sdk.service.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/services/initialize-sdk.service.ts
@@ -40,7 +40,7 @@ export class InitializeSdkService {
     this.onComponentUpdate = this.onComponentUpdate.bind(this);
   }
 
-  initialize({ initializePageModel = true, initializeRouterEvents = true } = {}): Subscription | void {
+  initialize({initializePageModel = true, initializeRouterEvents = true} = {}): Subscription | void {
     this.initializeCmsIntegration();
 
     if (initializePageModel) {

--- a/projects/bloomreach-experience-ng-sdk/src/lib/services/initialize-sdk.service.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/services/initialize-sdk.service.ts
@@ -40,7 +40,7 @@ export class InitializeSdkService {
     this.onComponentUpdate = this.onComponentUpdate.bind(this);
   }
 
-  initialize({initializePageModel = true, initializeRouterEvents = true} = {}): Subscription | void {
+  initialize({ initializePageModel = true, initializeRouterEvents = true } = {}): Subscription | void {
     this.initializeCmsIntegration();
 
     if (initializePageModel) {
@@ -67,13 +67,15 @@ export class InitializeSdkService {
       ? this.pageModelService.setPageModel(this.transferState.get(stateKey, null))
       : this.pageModelService.fetchPageModel();
 
-    $pageModel
-      .pipe(first())
-      .subscribe(() => {
-        if (hasState) {
-          this.transferState.remove(stateKey);
-        }
-      });
+    if ($pageModel) {
+      $pageModel
+        .pipe(first())
+        .subscribe(() => {
+          if (hasState) {
+            this.transferState.remove(stateKey);
+          }
+        });
+    }
 
     if (isPlatformServer(this.platformId) && this.transferState) {
       this.transferState.onSerialize(stateKey, () => this.pageModelService.pageModel);

--- a/projects/bloomreach-experience-ng-sdk/src/lib/services/page-model.service.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/services/page-model.service.ts
@@ -16,7 +16,7 @@
 
 import { Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
+import { BehaviorSubject, Observable, of, Subject} from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 import { ApiUrlsService } from './api-urls.service';
 import { RequestContextService } from './request-context.service';

--- a/projects/bloomreach-experience-ng-sdk/src/lib/services/page-model.service.ts
+++ b/projects/bloomreach-experience-ng-sdk/src/lib/services/page-model.service.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, Optional } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { BehaviorSubject, Observable, of, Subject} from 'rxjs';
+import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 import { ApiUrlsService } from './api-urls.service';
 import { RequestContextService } from './request-context.service';
@@ -47,17 +47,19 @@ export class PageModelService {
   constructor(
     private apiUrlsService: ApiUrlsService,
     private requestContextService: RequestContextService,
-    private http: HttpClient,
+    @Optional() private http: HttpClient,
   ) {
     this.pageModelSubject.subscribe(() => this.processPageModel());
   }
 
   fetchPageModel() {
     const apiUrl: string = this.buildApiUrl();
-    return this.http.get<any>(apiUrl, this.httpGetOptions).pipe(
-      tap(response => void this.setPageModel(response)),
-      catchError(this.handleError('fetchPageModel', undefined))
-    );
+    if (this.http) {
+      return this.http.get<any>(apiUrl, this.httpGetOptions).pipe(
+        tap(response => void this.setPageModel(response)),
+        catchError(this.handleError('fetchPageModel', undefined))
+      );
+    }
   }
 
   private processPageModel() {
@@ -98,19 +100,21 @@ export class PageModelService {
     const body: string = toUrlEncodedFormData(propertiesMap);
     const url: string = this.buildApiUrl(componentId);
 
-    return this.http.post<any>(url, body, this.httpPostOptions).pipe(
-      tap(response => {
-        const preview = this.requestContextService.isPreviewRequest();
-        this.setPageModel(_updateComponent(
-          response,
-          componentId,
-          this.pageModel,
-          this.channelManagerApi,
-          preview,
-          debugging
-        ));
-      }),
-      catchError(this.handleError('updateComponent', undefined)));
+    if (this.http) {
+      return this.http.post<any>(url, body, this.httpPostOptions).pipe(
+        tap(response => {
+          const preview = this.requestContextService.isPreviewRequest();
+          this.setPageModel(_updateComponent(
+            response,
+            componentId,
+            this.pageModel,
+            this.channelManagerApi,
+            preview,
+            debugging
+          ));
+        }),
+        catchError(this.handleError('updateComponent', undefined)));
+    }
   }
 
   getContentViaReference(contentRef: string): any {


### PR DESCRIPTION
When prerendering pages, the page model service attempts to use httpClient to retrieve page data. The httpClient uses xmlHttpRequest, which isn't available when prerendering on the server side.

The changes allow us to inject an appropriate http module that works on the server side.